### PR TITLE
feat: speach feature done, extension able to handle fr,sv,en,jp,es

### DIFF
--- a/src/hooks/useGetUserSettings.ts
+++ b/src/hooks/useGetUserSettings.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 type UserSettings = {
   targetLang: string;
+  sourceLang: string;
   voiceMode: boolean;
   dictionaryMode: boolean;
   lightMode: boolean;
@@ -15,6 +16,7 @@ export function useGetUserSettings() {
     chrome.storage.sync.get(null, (result) => {
       setSettings({
         targetLang: typeof result.targetLang === "string" ? result.targetLang : "sv",
+        sourceLang: typeof result.sourceLang === "string" ? result.sourceLang : "en",
         voiceMode: typeof result.voiceMode === "boolean" ? result.voiceMode : true,
         dictionaryMode: typeof result.dictionaryMode === "boolean" ? result.dictionaryMode : true,
         lightMode: typeof result.lightMode === "boolean" ? result.lightMode : true,

--- a/src/hooks/useSpeechSynthesis.ts
+++ b/src/hooks/useSpeechSynthesis.ts
@@ -1,64 +1,107 @@
 import { useEffect, useState } from "react";
 
-interface UseSpeechSynthesisOptions {
+type UseSpeechSynthesisOptions = {
   rate?: number;
   pitch?: number;
   volume?: number;
-}
+};
 
 export function useSpeechSynthesis(options: UseSpeechSynthesisOptions = {}) {
   const [isSpeaking, setIsSpeaking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [voicesReady, setVoicesReady] = useState(false);
 
-  const {
-    rate = 0.8, // Slightly slower for language learning
-    pitch = 0.7,
-    volume = 1,
-  } = options;
+  const { rate = 0.8, pitch = 1, volume = 1 } = options;
+
+  // Load voices on mount
+  useEffect(() => {
+    const loadVoices = () => {
+      const voices = window.speechSynthesis.getVoices();
+      if (voices.length > 0) {
+        console.log("Voices loaded:", voices.length);
+        setVoicesReady(true);
+      }
+    };
+
+    // Try immediately
+    loadVoices();
+
+    // Also listen for voice change event
+    window.speechSynthesis.addEventListener("voiceschanged", loadVoices);
+
+    return () => {
+      window.speechSynthesis.removeEventListener("voiceschanged", loadVoices);
+    };
+  }, []);
 
   const speak = (text: string, lang: string) => {
     if (!text || isSpeaking) return;
 
-    // Cancel any ongoing speech
     window.speechSynthesis.cancel();
 
     const utterance = new SpeechSynthesisUtterance(text);
-
-    // Set the language for proper pronunciation
     utterance.lang = lang;
-
-    // Configure voice parameters
     utterance.rate = rate;
     utterance.pitch = pitch;
     utterance.volume = volume;
 
-    // Handle speech events
-    utterance.onstart = () => {
-      setIsSpeaking(true);
-    };
+    // Get and set voice
+    const voices = window.speechSynthesis.getVoices();
+    console.log(voices);
 
-    utterance.onend = () => {
-      setIsSpeaking(false);
-    };
+    //Find a matching voice for the language
+    let selectedVoice: SpeechSynthesisVoice | undefined;
+    if (lang === "en") {
+      const macthingVoices = voices.filter((v) => v.lang.startsWith(lang));
+      selectedVoice = macthingVoices.find((v) => v.name === "Google UK English Male");
+      console.log(selectedVoice);
+    }
 
+    if (lang === "es") {
+      const macthingVoices = voices.filter((v) => v.lang.startsWith(lang));
+      selectedVoice = macthingVoices.find((v) => v.name === "Google español");
+      console.log(selectedVoice);
+    }
+
+    if (lang === "fr") {
+      const macthingVoices = voices.filter((v) => v.lang.startsWith(lang));
+      selectedVoice = macthingVoices.find((v) => v.name === "Google français");
+      console.log(selectedVoice);
+    }
+
+    if (lang === "ja") {
+      const macthingVoices = voices.filter((v) => v.lang.startsWith(lang));
+      selectedVoice = macthingVoices.find((v) => v.name === "Google 日本語");
+      console.log(selectedVoice);
+    }
+
+    if (selectedVoice) {
+      utterance.voice = selectedVoice;
+      console.log("Using voice:", selectedVoice.name);
+    }
+
+    utterance.onstart = () => setIsSpeaking(true);
+    utterance.onend = () => setIsSpeaking(false);
     utterance.onerror = (event) => {
       setIsSpeaking(false);
-      console.error("Speech synthesis error:", event.error);
+      setError(event.error);
     };
 
     window.speechSynthesis.speak(utterance);
   };
 
+  // Rest of your code...
   const cancel = () => {
     window.speechSynthesis.cancel();
     setIsSpeaking(false);
   };
 
-  // Cleanup: cancel any ongoing speech when component unmounts
   useEffect(() => {
     return () => {
       window.speechSynthesis.cancel();
     };
   }, []);
 
-  return { speak, cancel, isSpeaking };
+  //   return { speak, cancel, isSpeaking, error };
+  return { speak, cancel, isSpeaking, error, voicesReady };
 }

--- a/src/profileSettings.tsx
+++ b/src/profileSettings.tsx
@@ -5,7 +5,7 @@ import { useGetUserSettings } from "@/hooks/useGetUserSettings";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 
-type Language = "sv" | "fr" | "es" | "ja" | "";
+type Language = "sv" | "fr" | "es" | "ja" | "en" | "";
 
 type SwitchOption = {
   id: "voiceMode" | "dictionaryMode" | "lightMode";
@@ -52,34 +52,63 @@ export function ProfileSettings() {
   };
 
   // Update language in Chrome storage
-  const handleLanguageChange = (language: Language) => {
+  const handleTargetLanguageChange = (language: Language) => {
     chrome.storage.sync.set({ targetLang: language });
+  };
+
+  const handleSourceLanguageChange = (language: Language) => {
+    chrome.storage.sync.set({ sourceLang: language });
   };
 
   return (
     <div className="flex-1 overflow-y-auto rounded-xl border border-border bg-card">
       <div className="space-y-4 px-4 py-4">
         {/* Language Selection */}
-        <div className="space-y-2">
-          <Label htmlFor="language" className="text-xs font-medium text-foreground">
-            Translation Language
-          </Label>
-          <NativeSelect
-            size="sm"
-            className="w-full text-white"
-            id="language"
-            value={userSettings.targetLang}
-            onChange={(e) => handleLanguageChange(e.target.value as Language)}
-          >
-            <NativeSelectOption value="">Not selected</NativeSelectOption>
-            <NativeSelectOption value="sv">Swedish</NativeSelectOption>
-            <NativeSelectOption value="fr">French</NativeSelectOption>
-            <NativeSelectOption value="es">Spanish</NativeSelectOption>
-            <NativeSelectOption value="ja">Japanese</NativeSelectOption>
-          </NativeSelect>
-          <p className="text-[10px] text-muted-foreground">
-            Choose which language to translate text into
-          </p>
+        <div className="flex flex-col gap-3.5">
+          <div>
+            <Label htmlFor="language" className="text-xs font-semibold text-foreground">
+              Translation Language
+            </Label>
+            <p className="text-[10px] text-muted-foreground">
+              Choose which language to translate text into
+            </p>
+            <NativeSelect
+              size="sm"
+              className="w-full text-white"
+              id="language"
+              value={userSettings.targetLang}
+              onChange={(e) => handleTargetLanguageChange(e.target.value as Language)}
+            >
+              <NativeSelectOption value="">Not selected</NativeSelectOption>
+              <NativeSelectOption value="sv">Swedish</NativeSelectOption>
+              <NativeSelectOption value="fr">French</NativeSelectOption>
+              <NativeSelectOption value="es">Spanish</NativeSelectOption>
+              <NativeSelectOption value="ja">Japanese</NativeSelectOption>
+              <NativeSelectOption value="en">English</NativeSelectOption>
+            </NativeSelect>
+          </div>
+          <div>
+            <Label htmlFor="sourceLanguage" className="text-xs font-semibold text-foreground">
+              Source Language
+            </Label>
+            <p className="text-[10px] text-muted-foreground">
+              Choose which language to translate text from
+            </p>
+            <NativeSelect
+              size="sm"
+              className="w-full text-white"
+              id="sourceLanguage"
+              value={userSettings.sourceLang}
+              onChange={(e) => handleSourceLanguageChange(e.target.value as Language)}
+            >
+              <NativeSelectOption value="">Not selected</NativeSelectOption>
+              <NativeSelectOption value="sv">Swedish</NativeSelectOption>
+              <NativeSelectOption value="fr">French</NativeSelectOption>
+              <NativeSelectOption value="es">Spanish</NativeSelectOption>
+              <NativeSelectOption value="ja">Japanese</NativeSelectOption>
+              <NativeSelectOption value="en">English</NativeSelectOption>
+            </NativeSelect>
+          </div>
         </div>
 
         {/* Divider */}
@@ -88,10 +117,9 @@ export function ProfileSettings() {
         {/* Translation Display Options */}
         <div className="space-y-3">
           <div>
-            <h3 className="text-xs font-medium text-foreground">Display Options</h3>
-            <p className="text-[10px] text-muted-foreground">
-              Customize what appears in translations
-            </p>
+            <Label htmlFor="displayOptions" className="text-xs font-semibold text-foreground">
+              Translation toolbar options
+            </Label>
           </div>
 
           {/* Switches - Mapped from array */}

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -6,6 +6,7 @@ chrome.runtime.onInstalled.addListener(() => {
   // Initialize default settings on first install
   chrome.storage.sync.get(null, (result) => {
     const defaultSettings = {
+      sourceLang: result.sourceLang ?? "en",
       targetLang: result.targetLang ?? "sv",
       voiceMode: result.voiceMode ?? true, // Voice mode enabled by default
       dictionaryMode: result.dictionaryMode ?? true, // Dictionary mode enabled by default
@@ -40,6 +41,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   //Sending the marked text to the content script
   if (info.menuItemId === "translate-word" && tab?.id && info.selectionText) {
     const userSettings = await chrome.storage.sync.get([
+      "sourceLang",
       "targetLang",
       "voiceMode",
       "dictionaryMode",
@@ -52,6 +54,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       action: "SHOW_TRANSLATION",
       text: info.selectionText,
       length: info.selectionText.length,
+      sourceLang: userSettings.sourceLang,
       targetLang: userSettings.targetLang,
       voiceMode: userSettings.voiceMode,
       dictionaryMode: userSettings.dictionaryMode,

--- a/src/tooltipTranslation.tsx
+++ b/src/tooltipTranslation.tsx
@@ -34,8 +34,8 @@ export function TooltipTranslation() {
     }
   };
 
+  // TODO: Implement dictionary functionality
   const handleDictionary = () => {
-    // TODO: Implement dictionary functionality
     console.log("Dictionary lookup for:", originalText);
   };
 
@@ -65,7 +65,7 @@ export function TooltipTranslation() {
         // Update settings from the message (sent by service worker)
         setVoiceMode(message.voiceMode);
         setDictionaryMode(message.dictionaryMode);
-        setSourceLang("en"); // Currently hardcoded to English source
+        setSourceLang(message.sourceLang);
 
         // Get the current selection position
         const selection = window.getSelection();
@@ -89,7 +89,7 @@ export function TooltipTranslation() {
         try {
           //Check if the user has the necessary capabilities to translate the text
           const translatorCapabilities = await Translator.availability({
-            sourceLanguage: "en",
+            sourceLanguage: message.sourceLang,
             targetLanguage: message.targetLang,
           });
 
@@ -102,7 +102,7 @@ export function TooltipTranslation() {
 
           // Create translator (this might take time if model needs to be downloaded)
           const translator = await Translator.create({
-            sourceLanguage: "en",
+            sourceLanguage: message.sourceLang,
             targetLanguage: message.targetLang,
           });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type TranslationMessage = {
   action: string;
   text: string;
   length: number;
+  sourceLang: string;
   targetLang: string;
   voiceMode: boolean;
   dictionaryMode: boolean;
@@ -10,6 +11,7 @@ export type TranslationMessage = {
 
 export type UserSettings = {
   targetLang: string;
+  sourceLang: string;
   voiceMode: boolean;
   dictionaryMode: boolean;
   lightMode: boolean;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a configurable `sourceLang` and wires it through storage, types, service worker messaging, and the tooltip translator.
> 
> - Adds `sourceLang` to `UserSettings` and `TranslationMessage`; initializes defaults in `serviceWorker.ts`; passes through context menu message
> - Updates `profileSettings.tsx` to include Source and Target language selects (now includes English) and refined labels
> - `tooltipTranslation.tsx` now uses `message.sourceLang` for Translator availability/creation and speaking; removes hardcoded English
> - Enhances `useSpeechSynthesis`: adds error and `voicesReady` state, loads voices via `voiceschanged`, and selects language-specific Google voices for `en/es/fr/ja`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f31a060be17bd0babb348bfaeaee9fcca0b846d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->