### PR TITLE
feat: added shortcuts for open sidepanel and translating.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,13 +7,29 @@
     "default_popup": "dist/ui/popup.html",
     "default_icon": "images/icon.png"
   },
-  "side_panel": {
-    "default_path": "dist/ui/sidePanel.html"
-  },
   "icons": {
     "16": "images/icon.png",
     "48": "images/icon.png",
     "128": "images/icon.png"
+  },
+  "commands": {
+    "open-sidepanel": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+L",
+        "mac": "Command+Shift+L"
+      },
+      "description": "Open the Learnly side panel"
+    },
+    "translate-marked-text": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Y",
+        "mac": "Command+Shift+Y"
+      },
+      "description": "Translate the marked text"
+    }
+  },
+  "side_panel": {
+    "default_path": "dist/ui/sidePanel.html"
   },
   "background": {
     "service_worker": "dist/ui/serviceWorker.js",

--- a/src/background/serviceWorker.ts
+++ b/src/background/serviceWorker.ts
@@ -1,5 +1,5 @@
 console.log("Service Worker loaded");
-import type { TranslationMessage } from "@/types";
+import type { TranslationMessage, TranslationShortcutMessage } from "@/types";
 
 // Create the context menu on install and initialize default settings
 chrome.runtime.onInstalled.addListener(() => {
@@ -69,4 +69,19 @@ chrome.runtime.onMessage.addListener((message, sender) => {
     chrome.sidePanel.open({ tabId: sender.tab.id });
   }
 });
+
+// Listen for commands
+chrome.commands.onCommand.addListener((command, tab) => {
+  if (command === "open-sidepanel" && tab?.id) {
+    chrome.sidePanel.open({ tabId: tab.id });
+  }
+
+  if (command === "translate-marked-text" && tab?.id) {
+    chrome.tabs.sendMessage(tab.id, {
+      action: "SHOW_TRANSLATION_SHORTCUT",
+    } as TranslationShortcutMessage);
+  }
+});
+
+
 

--- a/src/side-panel/sidePanel.tsx
+++ b/src/side-panel/sidePanel.tsx
@@ -7,4 +7,3 @@ createRoot(document.getElementById("root-side-panel")!).render(
     <div>Hello from side panel</div>
   </StrictMode>
 );
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,10 @@ export type TranslationMessage = {
   lightMode: boolean;
 };
 
+export type TranslationShortcutMessage = {
+  action: string;
+};
+
 export type UserSettings = {
   targetLang: string;
   sourceLang: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces keyboard shortcuts and consolidates translation logic for a smoother UX.
> 
> - Adds `commands` in `manifest.json` for `open-sidepanel` and `translate-marked-text`; keeps `side_panel` path
> - Updates `serviceWorker.ts` to handle `chrome.commands`: opens side panel or sends `SHOW_TRANSLATION_SHORTCUT` to content; retains existing context menu behavior
> - Refactors `TooltipTranslation.tsx`: extracts `performTranslation`, handles `SHOW_TRANSLATION_SHORTCUT` by reading synced settings and translating the current selection; shares logic with context menu-triggered translation; minor cleanup
> - Adds `TranslationShortcutMessage` in `types.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8667376e067d9f609ea0f58748f3200bb4d2c62a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->